### PR TITLE
Revert "Add 'pyrealsense2' package to the installation list in dockerfile"

### DIFF
--- a/docker/drake_v4/Dockerfile
+++ b/docker/drake_v4/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get install -y \
     python3-dev \
     python3-opencv \
     libopencv-dev \ 
-    pyrealsense2 \
     ffmpeg  \
     libtbb2 libtbb-dev \ 
     libjpeg-dev \ 


### PR DESCRIPTION
Reverts ozay-group/kinova-arm#1

The pyrealsense2 has been installed. And this version WILL cause installation failure.